### PR TITLE
Handle UUID objects in expr.

### DIFF
--- a/pyrql/parser.py
+++ b/pyrql/parser.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import uuid
 from datetime import datetime
 
 import pyparsing as pp
@@ -120,6 +120,7 @@ TYPED_DATE = (K_DATE + COLON + common.iso8601_date).setParseAction(_date)
 TYPED_DATETIME = (K_DATETIME + COLON + common.iso8601_datetime).setParseAction(_datetime)
 TYPED_BOOL = (K_BOOL + COLON + (TRUE | FALSE))
 TYPED_EPOCH = (K_EPOCH + COLON + common.number).setParseAction(_epoch)
+TYPED_UUID = common.uuid.setParseAction(pp.tokenMap(uuid.UUID))
 
 TYPED_VALUE = (
     TYPED_EPOCH |
@@ -127,7 +128,8 @@ TYPED_VALUE = (
     TYPED_DATE |
     TYPED_NUMBER |
     TYPED_BOOL |
-    TYPED_STRING)
+    TYPED_STRING |
+    TYPED_UUID)
 
 ARRAY = pp.Forward()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+from uuid import UUID
 
 import pytest
 
@@ -179,3 +180,15 @@ class TestParser:
                         {'name': 'eq', 'args': ['gender', 'female']}]}
 
         assert pd == rep
+
+    @pytest.mark.parametrize('uuid_str', ['b999897c-c755-42b1-82f2-81cf6867b1c9',
+                                          '887670c3-5fa7-4dcf-a409-e8bf1d17fa5b'])
+    def test_uuid(self, uuid_str):
+        expr = 'uuid=%s' % uuid_str
+        pd = parse(expr)
+
+        rep = {'name': 'eq', 'args': [
+            'uuid', UUID(uuid_str)
+        ]}
+
+        assert rep == pd


### PR DESCRIPTION
Have added in UUID parsing so that uuid like strings can be correctly
parsed.

Previously, uuids beginning with an alpha character were getting correctly
parsed as strings but any uuid starting with an integer value were not getting parsed correctly.