### PR TITLE
Consistent equality operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/pyrql/parser.py
+++ b/pyrql/parser.py
@@ -110,8 +110,6 @@ STRING = pp.Combine(pp.OneOrMore(NCHAR))
 
 NAME = common.identifier
 
-NAME_ARRAY = NAME | (LPAR + pp.delimitedList(NAME) + RPAR).setParseAction(_array)
-
 NUMBER = common.number
 
 TYPED_STRING = (K_STRING + COLON + STRING)
@@ -152,7 +150,7 @@ FUNC_CALL = (NAME.setResultsName('name') + LPAR + pp.Group(pp.Optional(pp.delimi
 
 CALL_OPERATOR <<= (SORT_CALL | FUNC_CALL)
 
-COMPARISON = (NAME_ARRAY + EQUALS + pp.Optional(NAME + EQUALS) + VALUE).setParseAction(_comparison)
+COMPARISON = (VALUE + EQUALS + pp.Optional(NAME + EQUALS) + VALUE).setParseAction(_comparison)
 
 OPERATOR = pp.Forward()
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -40,10 +40,16 @@ class TestParser:
 
         assert pd == {'name': op, 'args': rep}
 
-    def test_equality_operator(self):
-        p1 = parse('lero=0')
-        p2 = parse('eq(lero, 0)')
+    @pytest.mark.parametrize('name, arg', [
+        ('lero', 'lero'),
+        ('foo.bar', 'foo.bar'),
+        ('(foo,bar)', ('foo', 'bar')),
+    ])
+    def test_equality_operator(self, name, arg):
+        p1 = parse('%s=0' % name)
+        p2 = parse('eq(%s, 0)' % name)
         assert p1 == p2
+        assert p1 == {'name': 'eq', 'args': [arg, 0]}
 
     def test_and_operator_pair(self):
         p1 = parse('eq(a,0)&eq(b,1)')


### PR DESCRIPTION
After testing this library I found, that I can do things like this:

    eq(foo.bar, 42)
    eq((foo,bar), 42)

But this is not possible with the shorthand syntax:

    foo.bar=42
    (foo,bar)=42

I think, this should be consistent and shorthand should allow same thing
as `eq()`.

What do you think?