### PR TITLE
Added repository URL to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.5.1"
 description = "RQL parsing"
 authors = ["Pedro Werneck <pjwerneck@gmail.com>"]
 license = "MIT"
+repository = "https://github.com/pjwerneck/pyrql"
 
 [tool.poetry.dependencies]
 python = "^3.5"


### PR DESCRIPTION
The [`repository` meta-data](https://python-poetry.org/docs/pyproject/#repository) makes it easier to find the project's GitHub URL on pypi. It would be nice to have it, so people can contribute or... drop a star more easily without looking up! 👍 