### PR TITLE
feat: allow unicode characters in strings

### DIFF
--- a/pyrql/parser.py
+++ b/pyrql/parser.py
@@ -115,7 +115,7 @@ LPAR = pp.Literal("(").suppress()
 RPAR = pp.Literal(")").suppress()
 COLON = pp.Literal(":").suppress()
 
-UNRESERVED = pp.Word(pp.alphanums + "-:._~ ", exact=1)
+UNRESERVED = pp.Word(pp.pyparsing_unicode.alphanums + "-:._~ ", exact=1)
 PCT_ENCODED = pp.Combine(pp.Literal("%") + pp.Word(pp.hexnums, exact=2)).setParseAction(
     _unquote
 )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,6 +21,7 @@ class TestParser:
             ("a(true)", [True]),
             ("a(false)", [False]),
             ("a(null)", [None]),
+            ("a(μéfoo中文кириллица)", ["μéfoo中文кириллица"])
         ],
     )
     def test_autoconverted_values(self, expr, args):


### PR DESCRIPTION
This PR will allow using unicode characters in rql strings.