### PR TITLE
Fix #10, add parseAll=True to avoid unbalanced parenthesis

### DIFF
--- a/pyrql/parser.py
+++ b/pyrql/parser.py
@@ -199,7 +199,7 @@ QUERY = pp.delimitedList(AND).setParseAction(_and)
 class Parser:
     def parse(self, expr):
         try:
-            result = QUERY.parseString(expr)
+            result = QUERY.parseString(expr, parseAll=True)
         except pp.ParseException as exc:
             raise RQLSyntaxError(*exc.args)
 

--- a/tests/test_reported.py
+++ b/tests/test_reported.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 
+from pyrql import RQLSyntaxError
 from pyrql import parse
 from pyrql import unparse
 
@@ -62,3 +64,16 @@ class TestReportedErrors:
 
         assert pd == rep
         assert upd == pd
+
+    def test_unbalanced_parenthesis_11(self):
+        parsed = parse(r"in(foo,(foo,bar))&sort(+foo)&eq(userid,user)")
+        assert parsed == {'name': 'and', 'args': [
+            {'name': 'in', 'args': ['foo', ('foo', 'bar')]},
+            {'name': 'sort', 'args': [('+', 'foo')]},
+            {'name': 'eq', 'args': ['userid', 'user']}
+        ]}
+
+        with pytest.raises(RQLSyntaxError) as exc:
+            parse(r"in(foo,(foo,bar))&sort(+foo))&eq(userid,user)")
+
+        assert exc.value.args[2] == "Expected end of text"


### PR DESCRIPTION
Without parseAll=True or pp.StringEnd() marking the end of
the string, the parser understands an unbalanced closing
parenthesis as the end, failing to parse the remaining
string, with the syntax error passing silently.