### PR TITLE
fix TypeError in Contains - when key is not present in data

### DIFF
--- a/pyrql/query.py
+++ b/pyrql/query.py
@@ -136,6 +136,10 @@ class Contains(RowNode):
     def __call__(self, row):
         key, value = self.args
         key = Key(key)
+
+        if not key(row):
+            return False
+
         return operator.contains(key(row), value)
 
 


### PR DESCRIPTION
TypeError - argument of type 'NoneType' is not iterable